### PR TITLE
Fixed `SKZoomingScrollView` Initialization

### DIFF
--- a/SKPhotoBrowser/SKZoomingScrollView.swift
+++ b/SKPhotoBrowser/SKZoomingScrollView.swift
@@ -34,14 +34,9 @@ open class SKZoomingScrollView: UIScrollView {
         setup()
     }
     
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setup()
-    }
-    
-    convenience init(frame: CGRect, browser: SKPhotoBrowser) {
-        self.init(frame: frame)
+    init(frame: CGRect, browser: SKPhotoBrowser) {
         self.browser = browser
+        super.init(frame: frame)
         setup()
     }
     


### PR DESCRIPTION
* When `SKZoomingScrollView` is initialized, the `setup()` method is called twice: once in `init(frame:)` and then once more in `init(frame:browser:)`
* Double call of `setup()` results in UI elements (such as `SKDetectingImageView`) created twice
* Even though `SKZoomingScrollView`’s properties (e.g. `imageView`) are reassigned on the second call of `setup()`, the UI elements remain in the view hierarchy and device’s memory
* To fix this, `init(frame:browser:)` has been to changed to be a designated initializer, and `init(frame:)` has been removed